### PR TITLE
Detabify and Unix old-manism

### DIFF
--- a/tryci
+++ b/tryci
@@ -1,5 +1,5 @@
-#!/bin/sh
-#
+#! /bin/sh
+
 # Script to emulate a CI job run on buildbot servers
 #
 # Each Dockerfile with the fliename prefix `.buildbot_dockerfile_` is tested


### PR DESCRIPTION
I mostly intended to detab `tryci` (https://github.com/softdevteam/tryci/commit/b4f3505350b450eaf0b1f97f4275300f2c352045) but then succumbed to irrelevant grumpy old man-ism (https://github.com/softdevteam/tryci/commit/a8698e87cefd8c3f5fd9c609889539edf444b46c). I can't help it sometimes!