### PR TITLE
Support custom bind-mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,33 @@ This works with the `--post-mortem` flag, so -- provided docker is installed --
 you can even use `TryCI` to prod around in a CI job on machines which you
 haven't cloned the original repo or setup to develop on.
 
+## Using bindmounts for faster build times
+
+Sometimes a CI build will depend on a submodule or external program which the
+`.buildbot.sh` script builds from source each time. For large projects (like
+`ykllvm`, which can take up to an hour to build) this can make build times
+significantly slower.
+
+Instead, you can mount arbitrarily many prebuilt programs from the host to be
+used inside the docker container using `-m/--mount` flag. You can specify
+multiple bind-mounts by repeating the option or by providing a comma-separated
+list:
+
+```
+-m /src:/dst -m /foo:/bar:ro
+-m /src:/dst,/foo:/bar:ro
+```
+If using this with the `--remote` flag, you must ensure the directory you wish
+to bind-mount exists on the remote machine -- it does not `scp` / `rsync` it
+over.
+
 ## Troubleshooting
 
 * Docker must be installed on both the local machine and remote machine used to
   compile and run the build.
 * Your user account on both the local and remote machine must be a member of the
   `docker` group.
-* If running CI on a remote machine (`--remote server_name`) you must use ssh
+* If running CI on a remote machine (`--remote <server_name>`) you must use ssh
   passwordless login (using public/private key pair).
 
 

--- a/tryci
+++ b/tryci
@@ -34,6 +34,14 @@ Must be run from the same directory as the job's .buildbot.sh file.
 usage: tryci [-p] [-r server_name] [-b <ref>] [-h]
 
 Options:
+  -m, --mount <mount> [<mount> ...]
+      Specify one or more bind-mounts. Each <mount> should be in the form:
+        <host-path>:<container-path>[:ro|rw]
+      You can specify multiple bind-mounts by repeating the option or by
+      providing a comma-separated list:
+        -m /src:/dst -m /foo:/bar:ro
+        -m /src:/dst,/foo:/bar:ro
+
   -p, --post-mortem
       Attach a shell to the image to prod around if the build fails.
 
@@ -182,7 +190,7 @@ build_image() {
     container_tag=$(docker create \
       ${CAP_ARGS} \
       -u "${ci_uid}" \
-      -v /opt/ykllvm_cache:/opt/ykllvm_cache:ro \
+      ${volumes}
       "${image_tag}")
 }
 
@@ -214,6 +222,7 @@ run_image() {
 pm=0
 server=""
 ref=""
+volumes="-v /opt/ykllvm_cache:/opt/ykllvm_cache:ro"
 
 while [ $# -gt 0 ]; do
   case $1 in
@@ -228,6 +237,25 @@ while [ $# -gt 0 ]; do
     -c | --checkout)
       ref="$2"
       shift 2
+      ;;
+    -m | --mounts)
+      # Support both repeated and comma-separated mounts
+      shift
+      if [[ -z "$1" || "$1" =~ ^- ]]; then
+        error "--mounts requires an argument."
+        exit 1
+      fi
+
+      IFS=',' read -ra mounts <<< "$1"
+      for m in "${mounts[@]}"; do
+        if [[ ! "$m" =~ ^[^:]+:[^:]+(:ro|:rw)?$ ]]; then
+          error "Invalid bind mount: '$m'"
+          error "Expected format: /host/path:/container/path[:ro|rw]"
+          exit 1
+        fi
+        volumes+=" -v $m"
+      done
+      shift
       ;;
     -h | --help)
       usage

--- a/tryci
+++ b/tryci
@@ -31,9 +31,19 @@ usage() {
 Runs a soft-dev CI job.
 Must be run from the same directory as the job's .buildbot.sh file.
 
-usage: tryci [-p] [-r server_name] [-b <ref>] [-h]
+usage: tryci [-h] [-c <ref>] [-m <mount>...] [-p] [-r <server-name>]
 
 Options:
+  -c, --checkout <ref>
+      Run a CI job from a clone of <ref> instead of the working tree. Valid
+      formats:
+      - Branch name (e.g., main, feature/x)
+      - Commit hash (e.g., a1b2c3d)
+      - Tag (e.g., v1.0.0)
+      - Remote-tracking branch (e.g., origin/main)
+      - Remote URL with branch (e.g., https://github.com/user/repo#branch)
+      Useful for debugging the exact version of a CI job that failed on CI.
+
   -m, --mount <mount> [<mount> ...]
       Specify one or more bind-mounts. Each <mount> should be in the form:
         <host-path>:<container-path>[:ro|rw]
@@ -45,19 +55,9 @@ Options:
   -p, --post-mortem
       Attach a shell to the image to prod around if the build fails.
 
-  -r, --remote server_name
-      Specify the server \`server_name\` to run the CI job on over SSH.
+  -r, --remote <server-name>
+      Specify the server <server-name> to run the CI job on over SSH.
       Useful if you want to test on a remote CI environment.
-
-  -c, --checkout <ref>
-      Tryci will run a CI job from a clone of <ref> instead of the
-      working tree. Valid formats:
-      - Branch name (e.g., main, feature/x)
-      - Commit hash (e.g., a1b2c3d)
-      - Tag (e.g., v1.0.0)
-      - Remote-tracking branch (e.g., origin/main)
-      - Remote URL with branch (e.g., https://github.com/user/repo#branch)
-      Useful for debugging the exact version of a CI job that failed on CI.
 
   -h, --help
       Show this help message and exit.


### PR DESCRIPTION
This adds a `TRYCI_BINDMOUNTS` environment variable, which can be used to mount arbitrary directories from the host to the docker container to be used in CI.

A common pattern I find myself myself repeating is using `tryci` to run the full test suite on `yk` and repeating it a lot once I inevitably find my change has broken something.

If my change includes an upstream change to `ykllvm` which hasn't landed yet, I can't take advantage of caching and have to wait almost an hour in-between builds.

This hack lets me reduce my tryci builds back down to about 10 minutes by letting me bind-mount a pre-built `ykllvm` from my host machine. It has similar uses for other submodules like bdwgc in alloy.