### PR TITLE
Use bash in shebang

### DIFF
--- a/tryci
+++ b/tryci
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /usr/bin/env bash
 
 # Script to emulate a CI job run on buildbot servers
 #


### PR DESCRIPTION
I've used bashisms in various parts of TryCi now and it would be a lie to call it portable. This stops bencher15 borking when it encounters the `[[` syntax in conditionals.